### PR TITLE
Fixed per torrent quality property name inconsistency

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -240,8 +240,8 @@ export default class CLI {
           if (!data[language]) data[language] = {};
           if (!data[language][quality]) data[language][quality] = {
             url: magnet,
-            seed: seeds,
-            peer: peers,
+            seeds: seeds,
+            peers: peers,
             size: result.length,
             filesize: bytes(result.length),
             provider: CLI._providerName

--- a/src/providers/extractors/movieextractor.js
+++ b/src/providers/extractors/movieextractor.js
@@ -79,8 +79,8 @@ export default class Extractor extends BaseExtractor {
     movie.torrents[language] = {};
     movie.torrents[language][quality] = {
       url: torrent.magnet ? torrent.magnet : torrent.torrent_link,
-      seed: torrent.seeds ? torrent.seeds : 0,
-      peer: torrent.peers ? torrent.peers : 0,
+      seeds: torrent.seeds ? torrent.seeds : 0,
+      peers: torrent.peers ? torrent.peers : 0,
       size: bytes(size.replace(/\s/g, "")),
       filesize: size,
       provider: this.name


### PR DESCRIPTION
The common per quality torrent includes `seeds `and `peers `but there are an inconsistency with movies, for movies are `seed `and `peer `thats we have to extend the torrent per quality object and override the getter for both properties.