### PR TITLE
Add a check that all images are fetched from the provider.

### DIFF
--- a/src/providers/helpers/animehelper.js
+++ b/src/providers/helpers/animehelper.js
@@ -43,9 +43,9 @@ export default class Helper {
     const saved = await Anime.findOneAndUpdate({
       _id: anime._id
     }, anime, {
-      new: true,
-      upsert: true
-    }).exec();
+        new: true,
+        upsert: true
+      }).exec();
 
     const distinct = await Anime.distinct("episodes.season", {
       _id: saved._id
@@ -55,9 +55,9 @@ export default class Helper {
     return await Anime.findOneAndUpdate({
       _id: saved._id
     }, saved, {
-      new: true,
-      upsert: true
-    }).exec();
+        new: true,
+        upsert: true
+      }).exec();
   }
 
   /**
@@ -151,7 +151,8 @@ export default class Helper {
         };
 
         episode.torrents = episodes[seasonNumber][episodeNumber];
-        episode.torrents[0] = episodes[seasonNumber][episodeNumber]["480p"] ? episodes[seasonNumber][episodeNumber]["480p"] : episodes[seasonNumber][episodeNumber]["720p"];
+        episode.torrents[0] = episodes[seasonNumber][episodeNumber]["480p"]
+          ? episodes[seasonNumber][episodeNumber]["480p"] : episodes[seasonNumber][episodeNumber]["720p"];
         anime.episodes.push(episode);
       });
     } catch (err) {
@@ -165,6 +166,8 @@ export default class Helper {
    * @returns {Anime} - A new anime without the episodes attached.
    */
   async getHummingbirdInfo(slug) {
+    const holder = "images/posterholder.png";
+
     try {
       const hummingbirdAnime = await this._hummingbird.Anime.getAnime(slug);
 
@@ -198,9 +201,9 @@ export default class Helper {
           num_seasons: 0,
           last_updated: Number(new Date()),
           images: {
-            banner: hummingbirdAnime.cover_image !== null ? hummingbirdAnime.cover_image : "images/posterholder.png",
-            fanart: hummingbirdAnime.cover_image !== null ? hummingbirdAnime.cover_image : "images/posterholder.png",
-            poster: hummingbirdAnime.cover_image !== null ? hummingbirdAnime.cover_image : "images/posterholder.png"
+            banner: hummingbirdAnime.cover_image !== null ? hummingbirdAnime.cover_image : holder,
+            fanart: hummingbirdAnime.cover_image !== null ? hummingbirdAnime.cover_image : holder,
+            poster: hummingbirdAnime.cover_image !== null ? hummingbirdAnime.cover_image : holder
           },
           genres: genres !== null ? genres : ["unknown"],
           episodes: []

--- a/src/providers/helpers/moviehelper.js
+++ b/src/providers/helpers/moviehelper.js
@@ -106,13 +106,13 @@ export default class Helper {
   }
 
   /**
-   * Get images from themoviedb.org or omdbapi.com.
+   * Get movie images.
    * @param {Integer} tmdb_id - The tmdb id of the movie you want the images from.
    * @param {String} imdb_id - The imdb id of the movie you want the images from.
    * @returns {Object} - Object with a banner, fanart and poster images.
    */
   async _getImages(tmdb_id, imdb_id) {
-    const holder = "images/posterholder.png"
+    const holder = "images/posterholder.png";
     const images = {
       banner: holder,
       fanart: holder,
@@ -131,21 +131,43 @@ export default class Helper {
       images.banner = tmdbPoster ? tmdbPoster : holder;
       images.fanart = tmdbBackdrop ? tmdbBackdrop : holder;
       images.poster = tmdbPoster ? tmdbPoster : holder;
+
+      this._util.checkImages(images, holder);
+
     } catch (err) {
       try {
         const omdbImages = await omdb.byID({
           imdb: imdb_id,
           type: "movie"
         });
-        images.banner = omdbImages.Poster ? omdbImages.Poster : holder;
-        images.fanart = omdbImages.Poster? omdbImages.Poster : holder;
-        images.poster = omdbImages.Poster ? omdbImages.Poster : holder;
+
+        if (images.banner === holder) {
+          images.banner = omdbImages.Poster ? omdbImages.Poster : holder;
+        }
+        if (images.fanart === holder) {
+          images.fanart = omdbImages.Poster ? omdbImages.Poster : holder;
+        }
+        if (images.poster === holder) {
+          images.poster = omdbImages.Poster ? omdbImages.Poster : holder;
+        }
+
+        this._util.checkImages(images, holder);
+
       } catch (err) {
         try {
           const fanartImages = await fanart.getMovieImages(tmdb_id);
-          images.banner = fanartImages.moviebanner ? fanartImages.moviebanner[0].url : holder;
-          images.fanart = fanartImages.moviebackground ? fanartImages.moviebackground[0].url : fanartImages.hdmovieclearart ? fanartImages.hdmovieclearart[0].url : holder;
-          images.poster = fanartImages.movieposter ? fanartImages.movieposter[0].url : holder;
+
+          if (images.banner === holder) {
+            images.banner = fanartImages.moviebanner ? fanartImages.moviebanner[0].url : holder;
+          }
+          if (images.fanart === holder) {
+            images.fanart = fanartImages.moviebackground
+              ? fanartImages.moviebackground[0].url : fanartImages.hdmovieclearart
+                ? fanartImages.hdmovieclearart[0].url : holder;
+          }
+          if (images.poster === holder) {
+            images.poster = fanartImages.movieposter ? fanartImages.movieposter[0].url : holder;
+          }
         } catch (err) {
           return this._util.onError(`Images: Could not find images on: ${err.path || err} with id: '${tmdb_id || imdb_id}'`);
         }
@@ -166,7 +188,7 @@ export default class Helper {
         id: slug,
         extended: "full"
       });
-      const traktWatchers = await trakt.movies.watching({id: slug});
+      const traktWatchers = await trakt.movies.watching({ id: slug });
 
       let watching = 0;
       if (traktWatchers !== null) watching = traktWatchers.length;

--- a/src/providers/helpers/showhelper.js
+++ b/src/providers/helpers/showhelper.js
@@ -35,9 +35,9 @@ export default class Helper {
     const saved = await Show.findOneAndUpdate({
       _id: show._id
     }, show, {
-      new: true,
-      upsert: true
-    }).exec();
+        new: true,
+        upsert: true
+      }).exec();
 
     const distinct = await Show.distinct("episodes.season", {
       _id: saved._id
@@ -47,9 +47,9 @@ export default class Helper {
     return await Show.findOneAndUpdate({
       _id: saved._id
     }, saved, {
-      new: true,
-      upsert: true
-    }).exec();
+        new: true,
+        upsert: true
+      }).exec();
   }
 
   /**
@@ -104,7 +104,7 @@ export default class Helper {
             .filter(showEpisode => showEpisode.season === found.episodes[i].season)
             .filter(showEpisode => showEpisode.episode === found.episodes[i].episode);
 
-            if (found.episodes[i].first_aired > show.latest_episode) show.latest_episode = found.episodes[i].first_aired;
+          if (found.episodes[i].first_aired > show.latest_episode) show.latest_episode = found.episodes[i].first_aired;
 
           if (matching.length != 0) {
             show = this._updateEpisode(matching[0], found.episodes[i], show, "480p");
@@ -189,26 +189,26 @@ export default class Helper {
             Object.keys(episodes[seasonNumber]).map(episodeNumber => {
               if (`${seasonNumber}-${episodeNumber}` === episodeData.FirstAired) {
                 const episode = {
-                    tvdb_id: episodeData.id,
-                    season: episodeData.SeasonNumber,
-                    episode: episodeData.EpisodeNumber,
-                    title: episodeData.EpisodeName,
-                    overview: episodeData.Overview,
-                    date_based: true,
-                    first_aired: new Date(episodeData.FirstAired).getTime() / 1000.0,
-                    watched: {
-                      watched: false
-                    },
-                    torrents: {}
-                  };
+                  tvdb_id: episodeData.id,
+                  season: episodeData.SeasonNumber,
+                  episode: episodeData.EpisodeNumber,
+                  title: episodeData.EpisodeName,
+                  overview: episodeData.Overview,
+                  date_based: true,
+                  first_aired: new Date(episodeData.FirstAired).getTime() / 1000.0,
+                  watched: {
+                    watched: false
+                  },
+                  torrents: {}
+                };
 
-                  if (episode.first_aired > show.latest_episode) show.latest_episode = episode.first_aired;
+                if (episode.first_aired > show.latest_episode) show.latest_episode = episode.first_aired;
 
-                  if (episode.season > 0) {
-                    episode.torrents = episodes[seasonNumber][episodeNumber];
-                    episode.torrents[0] = episodes[seasonNumber][episodeNumber]["480p"] ? episodes[seasonNumber][episodeNumber]["480p"] : episodes[seasonNumber][episodeNumber]["720p"];
-                    show.episodes.push(episode);
-                  }
+                if (episode.season > 0) {
+                  episode.torrents = episodes[seasonNumber][episodeNumber];
+                  episode.torrents[0] = episodes[seasonNumber][episodeNumber]["480p"] ? episodes[seasonNumber][episodeNumber]["480p"] : episodes[seasonNumber][episodeNumber]["720p"];
+                  show.episodes.push(episode);
+                }
               }
             });
           }
@@ -220,13 +220,13 @@ export default class Helper {
   }
 
   /**
-   * Get images from Fanart.tv on thetvdb.com.
+   * Get TV show images.
    * @param {Integer} tmdb_id - The tmdb id of the how you want the images from.
    * @param {Integer} tvdb_id - The tvdb id of the show you want the images from.
    * @returns {Object} - Object with a banner, fanart and poster images.
    */
   async _getImages(tmdb_id, tvdb_id) {
-    const holder = "images/posterholder.png"
+    const holder = "images/posterholder.png";
     const images = {
       banner: holder,
       fanart: holder,
@@ -245,19 +245,39 @@ export default class Helper {
       images.banner = tmdbPoster ? tmdbPoster : holder;
       images.fanart = tmdbBackdrop ? tmdbBackdrop : holder;
       images.poster = tmdbPoster ? tmdbPoster : holder;
+
+      this._checkImages(images, holder);
+
     } catch (err) {
       try {
         const tvdbImages = await tvdb.getSeriesById(tvdb_id);
-        images.banner = tvdbImages.banner ? `http://thetvdb.com/banners/${tvdbImages.banner}` : holder;
-        images.fanart = tvdbImages.fanart? `http://thetvdb.com/banners/${tvdbImages.fanart}` : holder;
-        images.poster = tvdbImages.poster ? `http://thetvdb.com/banners/${tvdbImages.poster}` : holder;
+
+        if (images.banner === holder) {
+          images.banner = tvdbImages.banner ? `http://thetvdb.com/banners/${tvdbImages.banner}` : holder;
+        }
+        if (images.fanart === holder) {
+          images.fanart = tvdbImages.fanart ? `http://thetvdb.com/banners/${tvdbImages.fanart}` : holder;
+        }
+        if (images.poster === holder) {
+          images.poster = tvdbImages.poster ? `http://thetvdb.com/banners/${tvdbImages.poster}` : holder;
+        }
+
+        this._util.checkImages(images, holder);
+
       } catch (err) {
         try {
           const fanartImages = await fanart.getShowImages(tvdb_id);
-          images.banner = fanartImages.tvbanner ? fanartImages.tvbanner[0].url : holder;
-          images.fanart = fanartImages.showbackground ? fanartImages.showbackground[0].url : fanartImages.clearart ? fanartImages.clearart[0].url : holder;
-          images.poster = fanartImages.tvposter ? fanartImages.tvposter[0].url : holder;
-        } catch(err) {
+
+          if (images.banner === holder) {
+            images.banner = fanartImages.tvbanner ? fanartImages.tvbanner[0].url : holder;
+          }
+          if (images.fanart === holder) {
+            images.fanart = fanartImages.showbackground ? fanartImages.showbackground[0].url : fanartImages.clearart ? fanartImages.clearart[0].url : holder;
+          }
+          if (images.poster === holder) {
+            images.poster = fanartImages.tvposter ? fanartImages.tvposter[0].url : holder;
+          }
+        } catch (err) {
           return this._util.onError(`Images: Could not find images on: ${err.path || err} with id: '${tmdb_id | tvdb_id}'`);
         }
       }

--- a/src/util.js
+++ b/src/util.js
@@ -131,4 +131,18 @@ export default class Util {
     }), () => {});
   }
 
+  /**
+   * Check that all images are fetched from the provider.
+   * @param {Object} images - The images.
+   * @param {String} holder - The image holder.
+   * @throws {Error} - 'An image could not been found'.
+   */
+  checkImages(images, holder) {
+    for (let image of images) {
+      if (image === holder) {
+        throw new Error('An image could not been found');
+      }
+    }
+  }
+  
 }


### PR DESCRIPTION
Introduces logic to fallback to the next provider if an image could not be found at the current provider.

How this works:
When fetching the images from a provider, it checks that all images aren't the default holder. If the check finds an unfetched image, it throws an error, causing the flow to jump to the next provider.