### PR TITLE
Update apiary.apib

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -313,7 +313,7 @@ Gives an array of movies. The array has a has a maximum length of 50 movies per 
               + `rating`
               + `released`
               + `trending`
-              + `updated`
+              + 'last added'
               + `year`
       + order (number, `-1`) - Order the list of content.
           + Values


### PR DESCRIPTION
Changing the 'updated' to 'last added' option for movies in the docs. (as the actual API has no 'updated' sort, but 'last added' works.)
